### PR TITLE
fix: default value and dom error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
   "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
   "files": {
     "ignoreUnknown": false,

--- a/pressbooks-select.js
+++ b/pressbooks-select.js
@@ -1,3 +1,5 @@
 import { PressbooksSelect } from './src/PressbooksSelect.js';
 
-window.customElements.define('pressbooks-select', PressbooksSelect);
+if (!window.customElements.get('pressbooks-select')) {
+  window.customElements.define('pressbooks-select', PressbooksSelect);
+}

--- a/src/PressbooksSelect.js
+++ b/src/PressbooksSelect.js
@@ -43,12 +43,12 @@ export class PressbooksSelect extends LitElement {
           --pb-button-font-family,
           -apple-system,
           BlinkMacSystemFont,
-          'Segoe UI',
+          "Segoe UI",
           Roboto,
           Oxygen-Sans,
           Ubuntu,
           Cantarell,
-          'Helvetica Neue',
+          "Helvetica Neue",
           sans-serif
         );
         font-size: var(--pb-button-font-size, 13px);
@@ -122,12 +122,12 @@ export class PressbooksSelect extends LitElement {
           --pb-input-font-family,
           -apple-system,
           BlinkMacSystemFont,
-          'Segoe UI',
+          "Segoe UI",
           Roboto,
           Oxygen-Sans,
           Ubuntu,
           Cantarell,
-          'Helvetica Neue',
+          "Helvetica Neue",
           sans-serif
         );
         font-size: var(--pb-input-font-size, 14px);
@@ -217,12 +217,12 @@ export class PressbooksSelect extends LitElement {
           --pb-combo-option-font-family,
           -apple-system,
           BlinkMacSystemFont,
-          'Segoe UI',
+          "Segoe UI",
           Roboto,
           Oxygen-Sans,
           Ubuntu,
           Cantarell,
-          'Helvetica Neue',
+          "Helvetica Neue",
           sans-serif
         );
         list-style: none;
@@ -245,7 +245,7 @@ export class PressbooksSelect extends LitElement {
         color: var(--pb-combo-option-color-active, #fff);
       }
 
-      .combo-option[aria-selected='true'] {
+      .combo-option[aria-selected="true"] {
         background: var(--pb-combo-option-background-selected, #d4002d);
         color: var(--pb-combo-option-color-selected, #fff);
       }
@@ -509,7 +509,6 @@ export class PressbooksSelect extends LitElement {
             ? this.selectionsTemplate()
             : nothing
         }
-        <pre>${this.value}</pre>
         ${
           this.htmlId !== '' && this.label !== ''
             ? this.comboBoxTemplate()
@@ -558,6 +557,10 @@ export class PressbooksSelect extends LitElement {
         this._select.querySelectorAll('option[selected]'),
       ).map(el => el.value);
       this.filteredOptions = this.options;
+      if (!this.multiple) {
+        this.value =
+          this._select.querySelector('option[selected]')?.textContent || '';
+      }
       this.groups = [
         ...new Set(
           Object.values(this.filteredOptions).map(option => option.group),


### PR DESCRIPTION
This pull request introduces minor improvements and fixes to the `PressbooksSelect` component and updates project configuration. The main changes include updating the schema version in `biome.json`, preventing duplicate custom element registration, standardizing font family quotes, fixing attribute selector syntax, and refining value initialization logic for single select mode.

**Configuration update:**
* Updated the `$schema` version in `biome.json` from `2.0.6` to `2.2.2` for improved tooling compatibility.

**Component registration:**
* Added a guard to prevent redefining the `pressbooks-select` custom element if it is already registered in `pressbooks-select.js`.

**Styling consistency:**
* Standardized font family values to use double quotes instead of single quotes in `src/PressbooksSelect.js`. [[1]](diffhunk://#diff-635cefc1acb47cf58a12ad7f7a8e0687d38628827d3e3f088d968842ca7129b4L46-R51) [[2]](diffhunk://#diff-635cefc1acb47cf58a12ad7f7a8e0687d38628827d3e3f088d968842ca7129b4L125-R130) [[3]](diffhunk://#diff-635cefc1acb47cf58a12ad7f7a8e0687d38628827d3e3f088d968842ca7129b4L220-R225)
* Updated the attribute selector for `.combo-option` to use double quotes for `aria-selected="true"` for consistency.

**Logic and rendering fixes:**
* Removed an unnecessary `<pre>${this.value}</pre>` output from the render template to clean up the UI in `src/PressbooksSelect.js`.
* Improved value initialization for single select mode to set `this.value` to the selected option's text content, ensuring correct display and behavior.